### PR TITLE
v1.0.4

### DIFF
--- a/_var.tf
+++ b/_var.tf
@@ -1,7 +1,7 @@
 variable "allow_external_principals" {
   description = "Whether or not to allow principals from outside your organization to participate in this share"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "associated_principals" {


### PR DESCRIPTION
Set the default value for `var.allow_external_principals` to false, because this seems like the more common desired value